### PR TITLE
Style Progress Updates and Evidence sections like Description/Criteria

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -434,6 +434,18 @@
   outline: 1px solid #ddd;
 }
 
+.markdown-body--updates {
+  background: #fafafa;
+  border: 10px solid #ecf8ec;
+  outline: 1px solid #ddd;
+}
+
+.markdown-body--evidence {
+  background: #fafafa;
+  border: 10px solid #f8ecec;
+  outline: 1px solid #ddd;
+}
+
 .markdown-body h1,
 .markdown-body h2,
 .markdown-body h3 {
@@ -462,11 +474,6 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.update-item {
-  border-left: 3px solid #ccc;
-  padding-left: 1rem;
 }
 
 .update-date {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -422,29 +422,18 @@
   padding: 0.75rem 1rem;
 }
 
-.markdown-body--description {
-  background: #fafafa;
-  border: 10px solid #f8f4ec;
-  outline: 1px solid #ddd;
-}
-
-.markdown-body--criteria {
-  background: #fafafa;
-  border: 10px solid #ececf8;
-  outline: 1px solid #ddd;
-}
-
-.markdown-body--updates {
-  background: #fafafa;
-  border: 10px solid #ecf8ec;
-  outline: 1px solid #ddd;
-}
-
+.markdown-body--description,
+.markdown-body--criteria,
+.markdown-body--updates,
 .markdown-body--evidence {
   background: #fafafa;
-  border: 10px solid #f8ecec;
   outline: 1px solid #ddd;
 }
+
+.markdown-body--description { border: 10px solid #f8f4ec; }
+.markdown-body--criteria    { border: 10px solid #ececf8; }
+.markdown-body--updates     { border: 10px solid #ecf8ec; }
+.markdown-body--evidence    { border: 10px solid #f8ecec; }
 
 .markdown-body h1,
 .markdown-body h2,

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -75,7 +75,7 @@ export default function TaskDetail() {
                 <time className="update-date">
                   {new Date(update.created_at).toLocaleDateString()}
                 </time>
-                <div className="markdown-body">
+                <div className="markdown-body markdown-body--updates">
                   <Markdown>{update.body}</Markdown>
                 </div>
               </li>
@@ -85,7 +85,7 @@ export default function TaskDetail() {
       )}
 
       {(task.status === "completed" || task.status === "review") && task.evidence && (
-        <MarkdownSection title="Completion Evidence">{task.evidence}</MarkdownSection>
+        <MarkdownSection title="Completion Evidence" className="markdown-body--evidence">{task.evidence}</MarkdownSection>
       )}
 
       {isAdmin && (

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -71,7 +71,7 @@ export default function TaskDetail() {
           <h2>Progress Updates</h2>
           <ul className="updates-list">
             {task.updates.map((update) => (
-              <li key={update.id} className="update-item">
+              <li key={update.id}>
                 <time className="update-date">
                   {new Date(update.created_at).toLocaleDateString()}
                 </time>


### PR DESCRIPTION
## Summary
- Add `markdown-body--updates` (soft green) and `markdown-body--evidence` (soft rose) CSS modifier classes matching the existing Description/Criteria styling pattern
- Apply the new styles to Progress Updates and Completion Evidence sections in TaskDetail
- Remove obsolete `.update-item` left-border styling
- Consolidate shared CSS properties (`background`, `outline`) across all four markdown-body modifiers

Closes #43

## Test plan
- [x] All 268 frontend tests pass (`npx vitest run`)
- [x] Visual check: task detail page with all four sections visible shows consistent styling with distinct border colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)