### PR TITLE
Add ideation stage with comment system (#46)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,25 +1,17 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 
-# Install Node.js 20 (frontend), PostgreSQL client (migrations/psql), and Docker CE (testcontainers)
+# Install Node.js 20 (frontend) and PostgreSQL server (tests)
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
        > /etc/apt/sources.list.d/nodesource.list \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg \
-       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
-       > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \
-        postgresql-client \
-        docker-ce docker-ce-cli containerd.io \
-    && rm -rf /var/lib/apt/lists/* \
-    && usermod -aG docker vscode \
-    && echo "vscode ALL=(root) NOPASSWD: /usr/bin/dockerd" > /etc/sudoers.d/docker \
-    && chmod 440 /etc/sudoers.d/docker
+        postgresql \
+    && rm -rf /var/lib/apt/lists/*
 
 # Pre-install Python dependencies globally (workspace mount overlays /workspace at runtime)
 COPY backend/pyproject.toml /tmp/backend/pyproject.toml

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 
 # Install Node.js 20 (frontend) and PostgreSQL client (migrations/psql)
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+       | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+       > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \
         postgresql-client \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,39 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 
-# Install Node.js 20 (frontend) and PostgreSQL client (migrations/psql)
+# Install Node.js 20 (frontend), PostgreSQL client (migrations/psql), and Docker CE (testcontainers)
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
        > /etc/apt/sources.list.d/nodesource.list \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+       | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \
         postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+        docker-ce docker-ce-cli containerd.io \
+    && rm -rf /var/lib/apt/lists/* \
+    && usermod -aG docker vscode \
+    && echo "vscode ALL=(root) NOPASSWD: /usr/bin/dockerd" > /etc/sudoers.d/docker \
+    && chmod 440 /etc/sudoers.d/docker
+
+# Pre-install Python dependencies globally (workspace mount overlays /workspace at runtime)
+COPY backend/pyproject.toml /tmp/backend/pyproject.toml
+RUN mkdir -p /tmp/backend/app && touch /tmp/backend/app/__init__.py \
+    && pip install --no-cache-dir /tmp/backend[dev] \
+    && rm -rf /tmp/backend
+ENV PYTHONPATH=/workspace/backend
+
+# Pre-populate npm cache so "npm install" at runtime is near-instant
+COPY frontend/package.json frontend/package-lock.json /tmp/frontend/
+RUN cd /tmp/frontend && npm ci --ignore-scripts && rm -rf /tmp/frontend
+
+COPY .devcontainer/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,9 +28,9 @@ RUN mkdir -p /tmp/backend/app && touch /tmp/backend/app/__init__.py \
     && rm -rf /tmp/backend
 ENV PYTHONPATH=/workspace/backend
 
-# Pre-populate npm cache so "npm install" at runtime is near-instant
-COPY frontend/package.json frontend/package-lock.json /tmp/frontend/
-RUN cd /tmp/frontend && npm ci --ignore-scripts && rm -rf /tmp/frontend
+# Pre-populate npm cache as vscode so it's usable at runtime
+COPY --chown=vscode:vscode frontend/package.json frontend/package-lock.json /tmp/frontend/
+RUN su vscode -c 'cd /tmp/frontend && npm ci --ignore-scripts' && rm -rf /tmp/frontend
 
 COPY .devcontainer/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# Install Node.js 20 (frontend) and PostgreSQL client (migrations/psql)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends \
+        nodejs \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,5 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "cd backend && pip install -e '.[dev]' && cd ../frontend && npm install",
-  "mounts": [
-    "source=coinoperated-pip-cache,target=/home/vscode/.cache/pip,type=volume",
-    "source=coinoperated-npm-cache,target=/home/vscode/.npm,type=volume"
-  ]
+  "postCreateCommand": "cd frontend && npm install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "coinoperated",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "postCreateCommand": "cd backend && pip install -e '.[dev]' && cd ../frontend && npm install",
+  "mounts": [
+    "source=coinoperated-pip-cache,target=/home/vscode/.cache/pip,type=volume",
+    "source=coinoperated-npm-cache,target=/home/vscode/.npm,type=volume"
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "postCreateCommand": "cd frontend && npm install"
+  "postCreateCommand": "pip install -e backend/ && cd frontend && npm install"
 }

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Start Docker daemon in the background if running privileged
+if command -v dockerd >/dev/null 2>&1; then
+    sudo dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
+    # Wait for Docker to be ready
+    for i in $(seq 1 30); do
+        docker info >/dev/null 2>&1 && break
+        sleep 1
+    done
+fi
+
+exec "$@"

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
-# Start Docker daemon in the background if running privileged
-if command -v dockerd >/dev/null 2>&1; then
-    sudo dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
-    for i in $(seq 1 30); do
-        docker info >/dev/null 2>&1 && break
-        sleep 1
-    done
-    docker info >/dev/null 2>&1 || echo "WARNING: Docker daemon did not start within 30s" >&2
-fi
+# Start PostgreSQL and create databases for development/testing
+
+pg_ctlcluster 15 main start 2>/dev/null || true
+
+su - postgres -c "psql -v ON_ERROR_STOP=0" >/dev/null 2>&1 <<'SQL'
+ALTER USER postgres PASSWORD 'postgres';
+SELECT 'CREATE DATABASE coinoperated' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'coinoperated') \gexec
+SELECT 'CREATE DATABASE coinoperated_test' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'coinoperated_test') \gexec
+SQL
 
 exec "$@"

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -2,11 +2,11 @@
 # Start Docker daemon in the background if running privileged
 if command -v dockerd >/dev/null 2>&1; then
     sudo dockerd --storage-driver=vfs >/tmp/dockerd.log 2>&1 &
-    # Wait for Docker to be ready
     for i in $(seq 1 30); do
         docker info >/dev/null 2>&1 && break
         sleep 1
     done
+    docker info >/dev/null 2>&1 || echo "WARNING: Docker daemon did not start within 30s" >&2
 fi
 
 exec "$@"

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 # Start PostgreSQL and create databases for development/testing
+# Uses sudo because the wrapper image runs as 'vscode', not root.
 
-pg_ctlcluster 15 main start 2>/dev/null || true
+sudo pg_ctlcluster 15 main start 2>/dev/null || true
 
-su - postgres -c "psql -v ON_ERROR_STOP=0" >/dev/null 2>&1 <<'SQL'
+sudo su - postgres -c "psql -v ON_ERROR_STOP=0" >/dev/null 2>&1 <<'SQL'
 ALTER USER postgres PASSWORD 'postgres';
 SELECT 'CREATE DATABASE coinoperated' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'coinoperated') \gexec
 SELECT 'CREATE DATABASE coinoperated_test' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'coinoperated_test') \gexec

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+backend/.venv
+frontend/node_modules
+__pycache__
+*.pyc
+.DS_Store

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,6 +32,20 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: coinoperated_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
 
@@ -46,6 +60,8 @@ jobs:
       - name: Run backend tests
         run: pytest tests/ -q
         working-directory: backend
+        env:
+          TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/coinoperated_test
 
   deploy:
     if: github.ref == 'refs/heads/prod' && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 __pycache__/
 *.egg-info/
 .env
+.venv/
 backend/env.yaml
 backend/static/
 .playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VENV := backend/.venv/bin
 STRIPE := $(or $(shell command -v stripe 2>/dev/null),$(HOME)/.local/bin/stripe)
 
-.PHONY: dev dev-backend dev-frontend db migrate install
+.PHONY: dev dev-backend dev-frontend db migrate install test-db
 
 # Start everything for local development
 dev: install
@@ -37,6 +37,13 @@ migrate:
 	docker compose up -d db
 	@until docker compose exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 0.5; done
 	cd backend && $(CURDIR)/$(VENV)/alembic upgrade head
+
+# Create test database (idempotent, for existing setups without init script)
+test-db:
+	docker compose up -d db
+	@until docker compose exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 0.5; done
+	@docker compose exec db psql -U postgres -tc "SELECT 1 FROM pg_database WHERE datname = 'coinoperated_test'" | grep -q 1 \
+		|| docker compose exec db psql -U postgres -c "CREATE DATABASE coinoperated_test"
 
 # Install all dependencies
 install:

--- a/backend/alembic/versions/0004_add_ideation_status.py
+++ b/backend/alembic/versions/0004_add_ideation_status.py
@@ -19,7 +19,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # ADD VALUE must be committed before the new value can be used,
+    # so run it outside the main transaction.
+    op.execute("COMMIT")
     op.execute("ALTER TYPE task_status ADD VALUE 'ideation' BEFORE 'proposed'")
+    op.execute("BEGIN")
 
     op.create_table(
         "comment",

--- a/backend/alembic/versions/0004_add_ideation_status.py
+++ b/backend/alembic/versions/0004_add_ideation_status.py
@@ -30,10 +30,13 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
 
+    op.create_index("ix_comment_task_id", "comment", ["task_id"])
+
     op.alter_column("task", "status", server_default="ideation")
 
 
 def downgrade() -> None:
     op.alter_column("task", "status", server_default="proposed")
+    op.drop_index("ix_comment_task_id", table_name="comment")
     op.drop_table("comment")
     # Note: PostgreSQL does not support removing enum values

--- a/backend/alembic/versions/0004_add_ideation_status.py
+++ b/backend/alembic/versions/0004_add_ideation_status.py
@@ -1,0 +1,39 @@
+"""add ideation status and comment table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-03-06 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0004"
+down_revision: Union[str, Sequence[str], None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE task_status ADD VALUE 'ideation' BEFORE 'proposed'")
+
+    op.create_table(
+        "comment",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("task_id", sa.UUID(), sa.ForeignKey("task.id"), nullable=False),
+        sa.Column("author_id", sa.UUID(), sa.ForeignKey("patron.id"), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.alter_column("task", "status", server_default="ideation")
+
+
+def downgrade() -> None:
+    op.alter_column("task", "status", server_default="proposed")
+    op.drop_table("comment")
+    # Note: PostgreSQL does not support removing enum values

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.routers import admin, auth, patron, patrons, pledges, tasks, webhooks
+from app.routers import admin, auth, comments, patron, patrons, pledges, tasks, webhooks
 
 
 def create_app() -> FastAPI:
@@ -25,6 +25,7 @@ def create_app() -> FastAPI:
     root.include_router(patrons.router)
     root.include_router(tasks.router)
     root.include_router(pledges.router)
+    root.include_router(comments.router)
     root.include_router(webhooks.router)
 
     @root.get("/api/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -27,6 +27,7 @@ class Base(DeclarativeBase):
 
 
 class TaskStatus(enum.StrEnum):
+    ideation = "ideation"
     proposed = "proposed"
     underway = "underway"
     review = "review"
@@ -109,8 +110,8 @@ class Task(Base):
     status: Mapped[TaskStatus] = mapped_column(
         Enum(TaskStatus, name="task_status", native_enum=True),
         nullable=False,
-        default=TaskStatus.proposed,
-        server_default="proposed",
+        default=TaskStatus.ideation,
+        server_default="ideation",
     )
     evidence: Mapped[str | None] = mapped_column(Text)
     pledge_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
@@ -127,6 +128,7 @@ class Task(Base):
     submitted_by_patron: Mapped[Patron | None] = relationship(back_populates="submitted_tasks")
     pledges: Mapped[list["Pledge"]] = relationship(back_populates="task")
     updates: Mapped[list["Update"]] = relationship(back_populates="task")
+    comments: Mapped[list["Comment"]] = relationship(back_populates="task")
 
 
 class Pledge(Base):
@@ -180,6 +182,27 @@ class Update(Base):
     )
 
     task: Mapped[Task] = relationship(back_populates="updates")
+
+
+class Comment(Base):
+    __tablename__ = "comment"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("task.id"), nullable=False
+    )
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("patron.id"), nullable=False
+    )
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    task: Mapped[Task] = relationship(back_populates="comments")
+    author: Mapped[Patron] = relationship()
 
 
 class Notification(Base):

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.dependencies import get_admin_patron, get_db
-from app.models import Notification, Patron, Pledge, PledgeStatus, Task, TaskStatus, Update
+from app.models import Comment, Notification, Patron, Pledge, PledgeStatus, Task, TaskStatus, Update
 from app.routers.tasks import get_task_or_404
 from app.schemas import (
     AdminPatronListResponse,
@@ -216,6 +216,7 @@ async def delete_task(
 ):
     await get_task_or_404(db, task_id)
 
+    await db.execute(delete(Comment).where(Comment.task_id == task_id))
     await db.execute(delete(Notification).where(Notification.task_id == task_id))
     await db.execute(delete(Update).where(Update.task_id == task_id))
     await db.execute(delete(Pledge).where(Pledge.task_id == task_id))

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -1,0 +1,44 @@
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.dependencies import get_active_patron, get_db
+from app.models import Comment, Patron
+from app.routers.tasks import get_task_or_404
+from app.schemas import CommentCreate, CommentRead
+
+router = APIRouter(prefix="/api/tasks/{task_id}/comments", tags=["comments"])
+
+
+@router.get("", response_model=list[CommentRead])
+async def list_comments(
+    task_id: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    await get_task_or_404(db, task_id)
+    result = await db.execute(
+        select(Comment)
+        .where(Comment.task_id == task_id)
+        .options(selectinload(Comment.author))
+        .order_by(Comment.created_at.asc())
+    )
+    return result.scalars().all()
+
+
+@router.post("", response_model=CommentRead, status_code=201)
+async def create_comment(
+    task_id: uuid.UUID,
+    payload: CommentCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    patron: Annotated[Patron, Depends(get_active_patron)],
+):
+    await get_task_or_404(db, task_id)
+    comment = Comment(task_id=task_id, author_id=patron.id, body=payload.body)
+    db.add(comment)
+    await db.commit()
+    await db.refresh(comment, attribute_names=["author"])
+    return comment

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from app.config import settings
 from app.dependencies import get_active_patron, get_admin_patron, get_db, get_session_factory
-from app.models import Patron, Task, TaskStatus
+from app.models import Comment, Patron, Task, TaskStatus
 from app.notifications import (
     notify_task_accepted,
     notify_task_completed,
@@ -23,6 +23,7 @@ from app.services.pledges import PaymentMethodOwnershipError, create_pledge_for_
 router = APIRouter(prefix="/api/tasks", tags=["tasks"])
 
 VALID_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
+    TaskStatus.ideation: {TaskStatus.proposed, TaskStatus.declined},
     TaskStatus.proposed: {TaskStatus.underway, TaskStatus.declined},
     TaskStatus.underway: {TaskStatus.review, TaskStatus.proposed},
     TaskStatus.review: {TaskStatus.collecting},
@@ -61,7 +62,10 @@ async def get_task_or_404(
 ) -> Task:
     query = select(Task).where(Task.id == task_id).options(selectinload(Task.submitted_by_patron))
     if load_updates:
-        query = query.options(selectinload(Task.updates))
+        query = query.options(
+            selectinload(Task.updates),
+            selectinload(Task.comments).selectinload(Comment.author),
+        )
     task = (await db.execute(query)).scalar_one_or_none()
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -82,13 +86,6 @@ async def create_task(
     db: Annotated[AsyncSession, Depends(get_db)],
     patron: Annotated[Patron, Depends(get_active_patron)],
 ):
-    is_admin = patron.email == settings.admin_email
-
-    if not is_admin and payload.pledge_amount is None:
-        raise HTTPException(
-            status_code=400, detail="A pledge is required when submitting a task"
-        )
-
     task = Task(
         title=payload.title,
         description=payload.description,
@@ -130,16 +127,30 @@ async def create_task(
     )
 
 
+AUTHOR_EDITABLE_FIELDS = {"title", "description", "criteria"}
+
+
 @router.patch("/{task_id}", response_model=TaskRead)
 async def update_task(
     task_id: uuid.UUID,
     payload: TaskUpdate,
     db: Annotated[AsyncSession, Depends(get_db)],
     background_tasks: BackgroundTasks,
-    _admin: Annotated[Patron, Depends(get_admin_patron)],
+    patron: Annotated[Patron, Depends(get_active_patron)],
     session_factory=Depends(get_session_factory),
 ):
     task = await get_task_or_404(db, task_id)
+    is_admin = patron.email == settings.admin_email
+    is_author = task.submitted_by == patron.id
+
+    if not is_admin:
+        if not (is_author and task.status == TaskStatus.ideation):
+            raise HTTPException(status_code=403, detail="Admin access required")
+        provided_fields = set(payload.model_dump(exclude_unset=True).keys())
+        if not provided_fields.issubset(AUTHOR_EDITABLE_FIELDS):
+            raise HTTPException(
+                status_code=403, detail="You can only edit title, description, and criteria in ideation"
+            )
 
     notify_fn = None
 

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -148,8 +148,9 @@ async def update_task(
             raise HTTPException(status_code=403, detail="Admin access required")
         provided_fields = set(payload.model_dump(exclude_unset=True).keys())
         if not provided_fields.issubset(AUTHOR_EDITABLE_FIELDS):
+            allowed = ", ".join(sorted(AUTHOR_EDITABLE_FIELDS))
             raise HTTPException(
-                status_code=403, detail="You can only edit title, description, and criteria in ideation"
+                status_code=403, detail=f"You can only edit {allowed} in ideation"
             )
 
     notify_fn = None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -66,6 +66,7 @@ class TaskRead(BaseReadSchema):
 
 class TaskDetail(TaskRead):
     updates: list["UpdateRead"] = []
+    comments: list["CommentRead"] = []
 
 
 class TaskCreateResponse(TaskRead):
@@ -219,6 +220,22 @@ class UpdateCreate(BaseModel):
 class UpdateRead(BaseReadSchema):
     id: uuid.UUID
     task_id: uuid.UUID
+    body: str
+    created_at: datetime
+
+
+# --- Comment ---
+
+
+class CommentCreate(BaseModel):
+    body: str = Field(min_length=1)
+
+
+class CommentRead(BaseReadSchema):
+    id: uuid.UUID
+    task_id: uuid.UUID
+    author_id: uuid.UUID
+    author: PatronPublicRead
     body: str
     created_at: datetime
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,7 +22,6 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=1.0",
     "httpx>=0.28",
-    "testcontainers[postgres]>=4.0",
     "ruff>=0.8",
 ]
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -7,7 +8,6 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text, update as sa_update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
-from testcontainers.postgres import PostgresContainer
 
 from app.auth import create_jwt
 from app.config import settings
@@ -16,22 +16,12 @@ from app.models import Base, EmailPreference, MagicLinkToken, Notification, Noti
 
 ADMIN_EMAIL = "admin@test.example.com"
 
-
-@pytest.fixture(scope="session")
-def postgres_container():
-    with PostgresContainer(
-        image="postgres:16-alpine",
-        username="postgres",
-        password="postgres",
-        dbname="coinoperated_test",
-        driver="asyncpg",
-    ) as pg:
-        yield pg
+DEFAULT_TEST_DB_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/coinoperated_test"
 
 
 @pytest.fixture(scope="session")
-def test_engine(postgres_container):
-    url = postgres_container.get_connection_url()
+def test_engine():
+    url = os.environ.get("TEST_DATABASE_URL", DEFAULT_TEST_DB_URL)
     return create_async_engine(url, poolclass=NullPool)
 
 
@@ -43,6 +33,7 @@ def test_session_maker(test_engine):
 @pytest.fixture(scope="session", autouse=True)
 async def setup_db(test_engine):
     async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
     yield
     await test_engine.dispose()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -12,7 +12,7 @@ from testcontainers.postgres import PostgresContainer
 from app.auth import create_jwt
 from app.config import settings
 from app.dependencies import get_db, get_session_factory
-from app.models import Base, EmailPreference, MagicLinkToken, Notification, NotificationType, Patron, Pledge, PledgeStatus, Task
+from app.models import Base, Comment, EmailPreference, MagicLinkToken, Notification, NotificationType, Patron, Pledge, PledgeStatus, Task
 
 ADMIN_EMAIL = "admin@test.example.com"
 
@@ -52,7 +52,7 @@ async def setup_db(test_engine):
 async def clean_tables(test_engine):
     yield
     async with test_engine.begin() as conn:
-        for table in ("email_preference", "notification", "magic_link_token", "update", "pledge", "task", "patron"):
+        for table in ("comment", "email_preference", "notification", "magic_link_token", "update", "pledge", "task", "patron"):
             await conn.execute(text(f'DELETE FROM "{table}"'))
 
 
@@ -153,7 +153,7 @@ async def create_patron(
 
 
 async def create_task(session_maker, **overrides) -> Task:
-    defaults = {"title": "Test task", "description": "A test task", "status": "proposed"}
+    defaults = {"title": "Test task", "description": "A test task", "status": "ideation"}
     defaults.update(overrides)
     async with session_maker() as session:
         task = Task(**defaults)
@@ -212,6 +212,15 @@ async def create_notification(
         await session.commit()
         await session.refresh(notification)
         return notification
+
+
+async def create_comment(session_maker, *, task_id, author_id, body="Test comment") -> Comment:
+    async with session_maker() as session:
+        comment = Comment(task_id=task_id, author_id=author_id, body=body)
+        session.add(comment)
+        await session.commit()
+        await session.refresh(comment)
+        return comment
 
 
 async def create_email_preference(

--- a/backend/tests/test_comments.py
+++ b/backend/tests/test_comments.py
@@ -1,0 +1,130 @@
+import uuid
+
+import pytest
+
+from tests.conftest import auth_cookies
+from tests.conftest import create_patron, create_task
+
+
+# --- GET /api/tasks/{task_id}/comments ---
+
+
+async def test_list_comments_empty(client, test_session_maker):
+    task = await create_task(test_session_maker)
+    resp = await client.get(f"/api/tasks/{task.id}/comments")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_comments_returns_items(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "commenter@example.com", "cus_c1")
+    task = await create_task(test_session_maker)
+
+    # Create a comment via API
+    resp = await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "Great idea!"},
+        cookies=auth_cookies(patron),
+    )
+    assert resp.status_code == 201
+
+    resp = await client.get(f"/api/tasks/{task.id}/comments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["body"] == "Great idea!"
+    assert data[0]["author"]["id"] == str(patron.id)
+
+
+async def test_list_comments_task_not_found(client):
+    resp = await client.get(f"/api/tasks/{uuid.uuid4()}/comments")
+    assert resp.status_code == 404
+
+
+# --- POST /api/tasks/{task_id}/comments ---
+
+
+async def test_create_comment_requires_auth(client, test_session_maker):
+    task = await create_task(test_session_maker)
+    resp = await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "Hello"},
+    )
+    assert resp.status_code == 401
+
+
+async def test_create_comment(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "commenter2@example.com", "cus_c2")
+    task = await create_task(test_session_maker)
+
+    resp = await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "I support this!"},
+        cookies=auth_cookies(patron),
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["body"] == "I support this!"
+    assert data["task_id"] == str(task.id)
+    assert data["author_id"] == str(patron.id)
+    assert "author" in data
+    assert data["author"]["id"] == str(patron.id)
+
+
+async def test_create_comment_empty_body(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "commenter3@example.com", "cus_c3")
+    task = await create_task(test_session_maker)
+
+    resp = await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": ""},
+        cookies=auth_cookies(patron),
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_comment_task_not_found(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "commenter4@example.com", "cus_c4")
+    resp = await client.post(
+        f"/api/tasks/{uuid.uuid4()}/comments",
+        json={"body": "Hello"},
+        cookies=auth_cookies(patron),
+    )
+    assert resp.status_code == 404
+
+
+async def test_comments_included_in_task_detail(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "commenter5@example.com", "cus_c5")
+    task = await create_task(test_session_maker)
+
+    await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "Comment one"},
+        cookies=auth_cookies(patron),
+    )
+    await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "Comment two"},
+        cookies=auth_cookies(patron),
+    )
+
+    resp = await client.get(f"/api/tasks/{task.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["comments"]) == 2
+    assert data["comments"][0]["body"] == "Comment one"
+    assert data["comments"][1]["body"] == "Comment two"
+
+
+async def test_banned_user_cannot_comment(client, test_session_maker):
+    banned = await create_patron(
+        test_session_maker, "banned@example.com", "cus_banned", is_banned=True
+    )
+    task = await create_task(test_session_maker)
+
+    resp = await client.post(
+        f"/api/tasks/{task.id}/comments",
+        json={"body": "Sneaky comment"},
+        cookies=auth_cookies(banned),
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_email_preferences.py
+++ b/backend/tests/test_email_preferences.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.models import NotificationType, PledgeStatus
+from app.models import NotificationType, PledgeStatus, TaskStatus
 from tests.conftest import (
     auth_cookies,
     create_email_preference,
@@ -122,7 +122,7 @@ class TestEmailPreferencesRespected:
     async def test_email_skipped_when_opted_out(
         self, mock_send, admin_client, client, test_session_maker, test_patron
     ):
-        task = await create_task(test_session_maker)
+        task = await create_task(test_session_maker, status=TaskStatus.proposed)
         await create_pledge(
             test_session_maker, patron_id=test_patron.id, task_id=task.id
         )
@@ -153,7 +153,7 @@ class TestEmailPreferencesRespected:
     async def test_email_sent_when_opted_in(
         self, mock_send, admin_client, test_session_maker, test_patron
     ):
-        task = await create_task(test_session_maker)
+        task = await create_task(test_session_maker, status=TaskStatus.proposed)
         await create_pledge(
             test_session_maker, patron_id=test_patron.id, task_id=task.id
         )
@@ -175,7 +175,7 @@ class TestEmailPreferencesRespected:
         self, mock_send, admin_client, test_session_maker, test_patron
     ):
         """Default behavior: email sent when no preference exists."""
-        task = await create_task(test_session_maker)
+        task = await create_task(test_session_maker, status=TaskStatus.proposed)
         await create_pledge(
             test_session_maker, patron_id=test_patron.id, task_id=task.id
         )

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -98,7 +98,7 @@ async def test_charge_failed_template(test_session_maker):
 @patch("app.notifications.send_email", new_callable=AsyncMock, return_value=True)
 async def test_task_accepted_creates_notification(mock_send, admin_client, test_session_maker):
     patron = await create_patron(test_session_maker, "notif_a@example.com", "cus_notif_a")
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
     await create_pledge(test_session_maker, patron_id=patron.id, task_id=task.id)
 
     resp = await admin_client.patch(
@@ -206,7 +206,7 @@ async def test_task_declined_creates_notification(mock_send, admin_client, test_
 async def test_multiple_pledgers_get_notifications(mock_send, admin_client, test_session_maker):
     patron1 = await create_patron(test_session_maker, "multi_a@example.com", "cus_multi_a")
     patron2 = await create_patron(test_session_maker, "multi_b@example.com", "cus_multi_b")
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
     await create_pledge(test_session_maker, patron_id=patron1.id, task_id=task.id)
     await create_pledge(
         test_session_maker, patron_id=patron2.id, task_id=task.id,
@@ -235,7 +235,7 @@ async def test_multiple_pledgers_get_notifications(mock_send, admin_client, test
 @patch("app.notifications.send_email", new_callable=AsyncMock, return_value=False)
 async def test_email_failure_does_not_break_api(mock_send, admin_client, test_session_maker):
     patron = await create_patron(test_session_maker, "fail@example.com", "cus_fail")
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
     await create_pledge(test_session_maker, patron_id=patron.id, task_id=task.id)
 
     resp = await admin_client.patch(
@@ -262,7 +262,7 @@ async def test_email_failure_does_not_break_api(mock_send, admin_client, test_se
 @patch("app.notifications.send_email", new_callable=AsyncMock, return_value=True)
 async def test_no_pledgers_no_notifications(mock_send, admin_client, test_session_maker):
     await create_task(test_session_maker)
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
 
     resp = await admin_client.patch(
         f"/api/tasks/{task.id}", json={"status": "underway"}
@@ -416,7 +416,7 @@ async def test_webhook_payment_failed_unknown_pledge_ignored(
 @patch("app.notifications.send_email", new_callable=AsyncMock, return_value=True)
 async def test_pending_pledger_not_notified(mock_send, admin_client, test_session_maker):
     patron = await create_patron(test_session_maker, "pending@example.com", "cus_pending")
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
     await create_pledge(
         test_session_maker,
         patron_id=patron.id,
@@ -498,7 +498,7 @@ async def test_send_pending_emails_mixed_success_failure(mock_send, test_session
 async def test_notification_persisted_before_email_sent(mock_send, admin_client, test_session_maker):
     """The notification row is committed to the DB before send_email runs."""
     patron = await create_patron(test_session_maker, "order@example.com", "cus_order")
-    task = await create_task(test_session_maker)
+    task = await create_task(test_session_maker, status=TaskStatus.proposed)
     await create_pledge(test_session_maker, patron_id=patron.id, task_id=task.id)
 
     notification_exists_at_send_time = []

--- a/backend/tests/test_patron.py
+++ b/backend/tests/test_patron.py
@@ -143,7 +143,7 @@ class TestNotificationCreation:
     async def test_notification_created_on_task_accepted(
         self, mock_send, admin_client, client, test_session_maker, test_patron
     ):
-        task = await create_task(test_session_maker, title="Paint mural")
+        task = await create_task(test_session_maker, title="Paint mural", status=TaskStatus.proposed)
         await create_pledge(
             test_session_maker, patron_id=test_patron.id, task_id=task.id
         )
@@ -228,7 +228,7 @@ class TestNotificationCreation:
         patron2 = await create_patron(
             test_session_maker, "patron2@example.com", "cus_p2"
         )
-        task = await create_task(test_session_maker, title="Shared task")
+        task = await create_task(test_session_maker, title="Shared task", status=TaskStatus.proposed)
         await create_pledge(
             test_session_maker,
             patron_id=test_patron.id,

--- a/backend/tests/test_pledges.py
+++ b/backend/tests/test_pledges.py
@@ -6,7 +6,13 @@ import stripe as stripe_module
 from app.auth import create_jwt
 from app.config import settings
 from app.models import Pledge, PledgeStatus, Task, TaskStatus
-from tests.conftest import create_patron, create_pledge, create_task, mock_setup_intent
+from tests.conftest import create_patron, create_pledge, create_task as _create_task, mock_setup_intent
+
+
+async def create_task(session_maker, **overrides):
+    """Create a task in proposed status by default (pledgeable)."""
+    overrides.setdefault("status", TaskStatus.proposed)
+    return await _create_task(session_maker, **overrides)
 
 # --- Helpers ---
 
@@ -108,6 +114,19 @@ async def test_create_pledge_task_not_pledgeable(client, test_session_maker):
         cookies=auth_cookies(patron.id),
     )
     assert resp.status_code == 400
+
+
+async def test_create_pledge_blocked_in_ideation(client, test_session_maker):
+    patron = await create_patron(test_session_maker, "ideation_pledge@example.com", "cus_ideation")
+    task = await create_task(test_session_maker, status=TaskStatus.ideation)
+
+    resp = await client.post(
+        f"/api/tasks/{task.id}/pledges",
+        json={"amount": 500},
+        cookies=auth_cookies(patron.id),
+    )
+    assert resp.status_code == 400
+    assert "not accepting pledges" in resp.json()["detail"].lower()
 
 
 # --- GET /api/tasks/{task_id}/pledges/me ---

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -41,6 +41,13 @@ async def create_task(client, **overrides):
     return resp.json()
 
 
+async def propose_task(client, task_id):
+    """Move a task from ideation to proposed."""
+    resp = await client.patch(f"/api/tasks/{task_id}", json={"status": "proposed"})
+    assert resp.status_code == 200
+    return resp.json()
+
+
 async def seed_tasks(client):
     a = await create_task(client, title="Task A", description="Desc A")
     b = await create_task(client, title="Task B", description="Desc B")
@@ -115,9 +122,11 @@ async def test_get_task(authed_client):
     assert data["title"] == "Fix the bus"
     assert data["description"] == "It's broken"
     assert data["criteria"] == "Bus works"
-    assert data["status"] == "proposed"
+    assert data["status"] == "ideation"
     assert "updates" in data
     assert data["updates"] == []
+    assert "comments" in data
+    assert data["comments"] == []
 
 
 async def test_get_task_not_found(client):
@@ -144,7 +153,7 @@ async def test_create_task_basic(authed_client, test_patron):
     assert resp.status_code == 201
     data = resp.json()
     assert data["title"] == "New task"
-    assert data["status"] == "proposed"
+    assert data["status"] == "ideation"
     assert data["submitted_by"] == str(test_patron.id)
     assert data["pledge_id"] is None
     assert data["client_secret"] is None
@@ -190,15 +199,17 @@ async def test_create_task_banned_user_gets_403(client, test_session_maker):
 # --- POST /api/tasks (non-admin pledge requirement) ---
 
 
-async def test_create_task_non_admin_requires_pledge(client, test_session_maker):
+async def test_create_task_non_admin_no_pledge_required(client, test_session_maker):
     patron = await create_patron_db(test_session_maker, "user@example.com", "cus_user")
     resp = await client.post(
         "/api/tasks",
         json={"title": "My task", "description": "Do something"},
         cookies=auth_cookies(patron),
     )
-    assert resp.status_code == 400
-    assert "pledge is required" in resp.json()["detail"].lower()
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "ideation"
+    assert data["pledge_id"] is None
 
 
 async def test_create_task_non_admin_pledge_below_minimum(client, test_session_maker):
@@ -233,7 +244,7 @@ async def test_create_task_non_admin_with_pledge(
     assert resp.status_code == 201
     data = resp.json()
     assert data["title"] == "My task"
-    assert data["status"] == "proposed"
+    assert data["status"] == "ideation"
     assert data["pledge_id"] is not None
     assert data["client_secret"] == "seti_test_secret"
     assert data["publishable_key"] == settings.stripe_publishable_key
@@ -275,7 +286,7 @@ async def test_update_task_requires_auth(client, test_session_maker):
 
 async def test_update_task_rejects_non_admin(client, test_session_maker):
     from tests.conftest import create_task as create_task_db
-    task = await create_task_db(test_session_maker)
+    task = await create_task_db(test_session_maker, status="proposed")
     non_admin = await create_patron_db(
         test_session_maker, "nonadmin@example.com", "cus_nonadmin"
     )
@@ -289,6 +300,7 @@ async def test_update_task_rejects_non_admin(client, test_session_maker):
 
 async def test_update_task_accept(authed_client):
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     resp = await authed_client.patch(
         f"/api/tasks/{task['id']}", json={"status": "underway"}
     )
@@ -298,8 +310,20 @@ async def test_update_task_accept(authed_client):
     assert data["underway_at"] is not None
 
 
-async def test_update_task_decline(authed_client):
+async def test_update_task_decline_from_ideation(authed_client):
     task = await create_task(authed_client)
+    resp = await authed_client.patch(
+        f"/api/tasks/{task['id']}", json={"status": "declined"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "declined"
+    assert data["declined_at"] is not None
+
+
+async def test_update_task_decline_from_proposed(authed_client):
+    task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     resp = await authed_client.patch(
         f"/api/tasks/{task['id']}", json={"status": "declined"}
     )
@@ -311,6 +335,7 @@ async def test_update_task_decline(authed_client):
 
 async def test_update_task_abandon(authed_client):
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
 
     resp = await authed_client.patch(
@@ -324,6 +349,7 @@ async def test_update_task_abandon(authed_client):
 
 async def test_update_task_review(authed_client):
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
 
     resp = await authed_client.patch(
@@ -338,6 +364,7 @@ async def test_update_task_review(authed_client):
 async def test_underway_to_collecting_invalid(authed_client):
     """Direct underway -> collecting is no longer valid; must go through review."""
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
 
     resp = await authed_client.patch(
@@ -350,7 +377,7 @@ async def test_underway_to_collecting_invalid(authed_client):
 async def test_update_task_invalid_transition(authed_client):
     task = await create_task(authed_client)
     resp = await authed_client.patch(
-        f"/api/tasks/{task['id']}", json={"status": "completed"}
+        f"/api/tasks/{task['id']}", json={"status": "underway"}
     )
     assert resp.status_code == 400
     assert "Invalid status transition" in resp.json()["detail"]
@@ -389,13 +416,14 @@ async def test_declined_is_terminal(authed_client):
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "declined"})
 
     resp = await authed_client.patch(
-        f"/api/tasks/{task['id']}", json={"status": "proposed"}
+        f"/api/tasks/{task['id']}", json={"status": "ideation"}
     )
     assert resp.status_code == 400
 
 
 async def test_completed_is_terminal(authed_client, test_session_maker):
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "review"})
     await backdate_review(test_session_maker, task["id"])
@@ -478,6 +506,7 @@ async def test_create_task_save_card_false(mock_si_create, client, test_session_
 async def test_review_to_collecting_too_early(authed_client, test_session_maker):
     """Cannot transition review -> collecting before 1 week."""
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "review"})
 
@@ -491,6 +520,7 @@ async def test_review_to_collecting_too_early(authed_client, test_session_maker)
 async def test_review_to_collecting_after_week(authed_client, test_session_maker):
     """Can transition review -> collecting after 1 week."""
     task = await create_task(authed_client)
+    await propose_task(authed_client, task["id"])
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "underway"})
     await authed_client.patch(f"/api/tasks/{task['id']}", json={"status": "review"})
     await backdate_review(test_session_maker, task["id"])
@@ -500,3 +530,138 @@ async def test_review_to_collecting_after_week(authed_client, test_session_maker
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == "collecting"
+
+
+# --- Ideation phase tests ---
+
+
+async def test_ideation_to_proposed(authed_client):
+    task = await create_task(authed_client)
+    assert task["status"] == "ideation"
+    resp = await authed_client.patch(
+        f"/api/tasks/{task['id']}", json={"status": "proposed"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "proposed"
+
+
+async def test_ideation_to_declined(authed_client):
+    task = await create_task(authed_client)
+    resp = await authed_client.patch(
+        f"/api/tasks/{task['id']}", json={"status": "declined"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "declined"
+
+
+async def test_ideation_to_underway_invalid(authed_client):
+    task = await create_task(authed_client)
+    resp = await authed_client.patch(
+        f"/api/tasks/{task['id']}", json={"status": "underway"}
+    )
+    assert resp.status_code == 400
+    assert "Invalid status transition" in resp.json()["detail"]
+
+
+# --- Author editing in ideation ---
+
+
+async def test_author_can_edit_in_ideation(client, test_session_maker):
+    author = await create_patron_db(test_session_maker, "author@example.com", "cus_author")
+    # Create task as author
+    resp = await client.post(
+        "/api/tasks",
+        json={"title": "My idea", "description": "Draft"},
+        cookies=auth_cookies(author),
+    )
+    assert resp.status_code == 201
+    task = resp.json()
+    assert task["status"] == "ideation"
+
+    # Author edits title/description/criteria
+    resp = await client.patch(
+        f"/api/tasks/{task['id']}",
+        json={"title": "Updated idea", "description": "Better draft", "criteria": "New criteria"},
+        cookies=auth_cookies(author),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Updated idea"
+    assert data["description"] == "Better draft"
+    assert data["criteria"] == "New criteria"
+
+
+async def test_author_cannot_change_status_in_ideation(client, test_session_maker):
+    author = await create_patron_db(test_session_maker, "author2@example.com", "cus_author2")
+    resp = await client.post(
+        "/api/tasks",
+        json={"title": "My idea", "description": "Draft"},
+        cookies=auth_cookies(author),
+    )
+    task = resp.json()
+
+    resp = await client.patch(
+        f"/api/tasks/{task['id']}",
+        json={"status": "proposed"},
+        cookies=auth_cookies(author),
+    )
+    assert resp.status_code == 403
+
+
+async def test_author_cannot_set_evidence_in_ideation(client, test_session_maker):
+    author = await create_patron_db(test_session_maker, "author_ev@example.com", "cus_author_ev")
+    resp = await client.post(
+        "/api/tasks",
+        json={"title": "My idea", "description": "Draft"},
+        cookies=auth_cookies(author),
+    )
+    task = resp.json()
+
+    resp = await client.patch(
+        f"/api/tasks/{task['id']}",
+        json={"evidence": "Sneaky evidence"},
+        cookies=auth_cookies(author),
+    )
+    assert resp.status_code == 403
+    assert "only edit title" in resp.json()["detail"].lower()
+
+
+async def test_author_cannot_edit_after_ideation(client, authed_client, test_session_maker):
+    author = await create_patron_db(test_session_maker, "author3@example.com", "cus_author3")
+    resp = await client.post(
+        "/api/tasks",
+        json={"title": "My idea", "description": "Draft"},
+        cookies=auth_cookies(author),
+    )
+    task = resp.json()
+
+    # Admin moves to proposed
+    await authed_client.patch(
+        f"/api/tasks/{task['id']}", json={"status": "proposed"}
+    )
+
+    # Author tries to edit in proposed
+    resp = await client.patch(
+        f"/api/tasks/{task['id']}",
+        json={"title": "Too late"},
+        cookies=auth_cookies(author),
+    )
+    assert resp.status_code == 403
+
+
+async def test_non_author_cannot_edit_in_ideation(client, test_session_maker):
+    author = await create_patron_db(test_session_maker, "author4@example.com", "cus_author4")
+    other = await create_patron_db(test_session_maker, "other@example.com", "cus_other")
+    resp = await client.post(
+        "/api/tasks",
+        json={"title": "My idea", "description": "Draft"},
+        cookies=auth_cookies(author),
+    )
+    task = resp.json()
+
+    resp = await client.patch(
+        f"/api/tasks/{task['id']}",
+        json={"title": "Hijacked"},
+        cookies=auth_cookies(other),
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -623,7 +623,7 @@ async def test_author_cannot_set_evidence_in_ideation(client, test_session_maker
         cookies=auth_cookies(author),
     )
     assert resp.status_code == 403
-    assert "only edit title" in resp.json()["detail"].lower()
+    assert "only edit" in resp.json()["detail"].lower()
 
 
 async def test_author_cannot_edit_after_ideation(client, authed_client, test_session_maker):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./docker/init-test-db.sql:/docker-entrypoint-initdb.d/init-test-db.sql:ro
 
 volumes:
   pgdata:

--- a/docker/init-test-db.sql
+++ b/docker/init-test-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE coinoperated_test;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -230,6 +230,10 @@
   letter-spacing: 0;
 }
 
+.status-ideation {
+  background: #f0e6f4;
+  color: #6a3d7d;
+}
 .status-proposed {
   background: #e6f4e6;
   color: #2a7a2a;
@@ -468,6 +472,53 @@
 .update-date {
   font-size: 0.8rem;
   color: #888;
+}
+
+.comments-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.comment-item {
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.75rem;
+}
+
+.comment-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.comment-author {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.comment-date {
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.comment-textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  resize: vertical;
 }
 
 .task-detail-cta {

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,0 +1,10 @@
+import { API_BASE, fetchJson } from "./client";
+import type { CommentRead } from "./types";
+
+export async function createComment(taskId: string, body: string): Promise<CommentRead> {
+  return fetchJson(`${API_BASE}/tasks/${taskId}/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body }),
+  });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,4 +1,4 @@
-export type TaskStatus = "proposed" | "underway" | "review" | "collecting" | "completed" | "declined";
+export type TaskStatus = "ideation" | "proposed" | "underway" | "review" | "collecting" | "completed" | "declined";
 
 export interface PatronPublicRead {
   id: string;
@@ -32,8 +32,18 @@ export interface UpdateRead {
   created_at: string;
 }
 
+export interface CommentRead {
+  id: string;
+  task_id: string;
+  author_id: string;
+  author: PatronPublicRead;
+  body: string;
+  created_at: string;
+}
+
 export interface TaskDetailRead extends TaskRead {
   updates: UpdateRead[];
+  comments: CommentRead[];
 }
 
 export interface TaskListResponse {

--- a/frontend/src/components/AdminTaskActions.test.tsx
+++ b/frontend/src/components/AdminTaskActions.test.tsx
@@ -107,4 +107,28 @@ describe("AdminTaskActions", () => {
     await userEvent.click(screen.getByRole("button", { name: "Accept" }));
     expect(await screen.findByText("Server error")).toBeInTheDocument();
   });
+
+  it("shows Move to Proposed and Decline buttons for ideation tasks", () => {
+    render(<AdminTaskActions task={makeTask({ status: "ideation" })} onAction={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Move to Proposed" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeInTheDocument();
+  });
+
+  it("calls patchTask with proposed on Move to Proposed click", async () => {
+    const onAction = vi.fn();
+    mockPatchTask.mockResolvedValue(makeTask({ status: "proposed" }));
+    render(<AdminTaskActions task={makeTask({ status: "ideation", id: "t1" })} onAction={onAction} />);
+    await userEvent.click(screen.getByRole("button", { name: "Move to Proposed" }));
+    expect(mockPatchTask).toHaveBeenCalledWith("t1", { status: "proposed" });
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it("calls patchTask with declined on ideation Decline click", async () => {
+    const onAction = vi.fn();
+    mockPatchTask.mockResolvedValue(makeTask({ status: "declined" }));
+    render(<AdminTaskActions task={makeTask({ status: "ideation", id: "t1" })} onAction={onAction} />);
+    await userEvent.click(screen.getByRole("button", { name: "Decline" }));
+    expect(mockPatchTask).toHaveBeenCalledWith("t1", { status: "declined" });
+    expect(onAction).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/AdminTaskActions.tsx
+++ b/frontend/src/components/AdminTaskActions.tsx
@@ -45,6 +45,25 @@ export default function AdminTaskActions({
     <>
       {error && <p className="admin-error">{error}</p>}
 
+      {task.status === "ideation" && (
+        <>
+          <button
+            className="btn btn-accept"
+            disabled={busy}
+            onClick={() => handleAction(() => patchTask(task.id, { status: "proposed" }))}
+          >
+            {busy ? <Spinner /> : "Move to Proposed"}
+          </button>
+          <button
+            className="btn btn-decline"
+            disabled={busy}
+            onClick={() => handleAction(() => patchTask(task.id, { status: "declined" }))}
+          >
+            {busy ? <Spinner /> : "Decline"}
+          </button>
+        </>
+      )}
+
       {task.status === "proposed" && (
         <>
           <button

--- a/frontend/src/components/CommentSection.test.tsx
+++ b/frontend/src/components/CommentSection.test.tsx
@@ -1,0 +1,134 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommentSection from "./CommentSection";
+import { createComment } from "../api/comments";
+import { makeComment } from "../test/factories";
+import { renderWithRouter } from "../test/render";
+
+vi.mock("../api/comments");
+const mockCreateComment = vi.mocked(createComment);
+
+const mockUseAuth = vi.fn();
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: (...args: unknown[]) => mockUseAuth(...args),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CommentSection", () => {
+  it("shows empty state when no comments", () => {
+    mockUseAuth.mockReturnValue({ patron: null, loading: false });
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+    expect(screen.getByText("Comments")).toBeInTheDocument();
+    expect(screen.getByText("No comments yet.")).toBeInTheDocument();
+  });
+
+  it("renders comments with author and body", () => {
+    mockUseAuth.mockReturnValue({ patron: null, loading: false });
+    const comments = [
+      makeComment({ id: "c1", body: "First comment", author: { id: "p1", display_name: "Alice", created_at: "2025-01-01T00:00:00Z" } }),
+      makeComment({ id: "c2", body: "Second comment", author: { id: "p2", display_name: null, created_at: "2025-01-01T00:00:00Z" } }),
+    ];
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={comments} onComment={vi.fn()} />,
+    );
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("First comment")).toBeInTheDocument();
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    expect(screen.getByText("Second comment")).toBeInTheDocument();
+  });
+
+  it("hides comment form when not logged in", () => {
+    mockUseAuth.mockReturnValue({ patron: null, loading: false });
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+    expect(screen.queryByPlaceholderText(/add a comment/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Post Comment" })).not.toBeInTheDocument();
+  });
+
+  it("shows comment form when logged in", () => {
+    mockUseAuth.mockReturnValue({ patron: { id: "p1" }, loading: false });
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+    expect(screen.getByPlaceholderText(/add a comment/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Post Comment" })).toBeInTheDocument();
+  });
+
+  it("disables submit button when textarea is empty", () => {
+    mockUseAuth.mockReturnValue({ patron: { id: "p1" }, loading: false });
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: "Post Comment" })).toBeDisabled();
+  });
+
+  it("submits a comment and calls onComment", async () => {
+    const onComment = vi.fn();
+    mockUseAuth.mockReturnValue({ patron: { id: "p1" }, loading: false });
+    mockCreateComment.mockResolvedValue(makeComment({ body: "New comment" }));
+
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={onComment} />,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/add a comment/i), "New comment");
+    await userEvent.click(screen.getByRole("button", { name: "Post Comment" }));
+
+    await waitFor(() => {
+      expect(mockCreateComment).toHaveBeenCalledWith("t1", "New comment");
+    });
+    expect(onComment).toHaveBeenCalled();
+    // Textarea should be cleared
+    expect(screen.getByPlaceholderText(/add a comment/i)).toHaveValue("");
+  });
+
+  it("shows error when comment submission fails", async () => {
+    mockUseAuth.mockReturnValue({ patron: { id: "p1" }, loading: false });
+    mockCreateComment.mockRejectedValue(new Error("Failed to post"));
+
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/add a comment/i), "Bad comment");
+    await userEvent.click(screen.getByRole("button", { name: "Post Comment" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to post")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Posting... while submitting", async () => {
+    mockUseAuth.mockReturnValue({ patron: { id: "p1" }, loading: false });
+    mockCreateComment.mockReturnValue(new Promise(() => {})); // never resolves
+
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={[]} onComment={vi.fn()} />,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/add a comment/i), "A comment");
+    await userEvent.click(screen.getByRole("button", { name: "Post Comment" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Posting..." })).toBeDisabled();
+    });
+  });
+
+  it("links author name to patron profile", () => {
+    mockUseAuth.mockReturnValue({ patron: null, loading: false });
+    const comments = [
+      makeComment({ author: { id: "patron-42", display_name: "Bob", created_at: "2025-01-01T00:00:00Z" } }),
+    ];
+    renderWithRouter(
+      <CommentSection taskId="t1" comments={comments} onComment={vi.fn()} />,
+    );
+    const link = screen.getByRole("link", { name: "Bob" });
+    expect(link).toHaveAttribute("href", "/patrons/patron-42");
+  });
+});

--- a/frontend/src/components/CommentSection.tsx
+++ b/frontend/src/components/CommentSection.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import Markdown from "react-markdown";
+import { createComment } from "../api/comments";
+import type { CommentRead } from "../api/types";
+import { useAuth } from "../contexts/AuthContext";
+import { getErrorMessage } from "../utils/formatting";
+import { Link } from "react-router-dom";
+
+export default function CommentSection({
+  taskId,
+  comments,
+  onComment,
+}: {
+  taskId: string;
+  comments: CommentRead[];
+  onComment: () => void;
+}) {
+  const { patron } = useAuth();
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!body.trim()) return;
+
+    setSubmitting(true);
+    setError("");
+    try {
+      await createComment(taskId, body.trim());
+      setBody("");
+      onComment();
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="task-detail-section">
+      <h2>Comments</h2>
+
+      {comments.length === 0 && <p className="page-message">No comments yet.</p>}
+
+      <ul className="comments-list">
+        {comments.map((comment) => (
+          <li key={comment.id} className="comment-item">
+            <div className="comment-meta">
+              <Link to={`/patrons/${comment.author.id}`} className="comment-author">
+                {comment.author.display_name ?? "Anonymous"}
+              </Link>
+              <time className="comment-date">
+                {new Date(comment.created_at).toLocaleDateString()}
+              </time>
+            </div>
+            <div className="markdown-body">
+              <Markdown>{comment.body}</Markdown>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {patron && (
+        <form onSubmit={handleSubmit} className="comment-form">
+          <textarea
+            className="comment-textarea"
+            placeholder="Add a comment (Markdown supported)..."
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={3}
+          />
+          {error && <p className="form-error">{error}</p>}
+          <button
+            type="submit"
+            className="btn btn-primary btn-sm"
+            disabled={submitting || !body.trim()}
+          >
+            {submitting ? "Posting..." : "Post Comment"}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -3,6 +3,7 @@ import type { TaskStatus } from "../api/types";
 import { statusLabel } from "../utils/formatting";
 
 const GLOSSARY: { status: TaskStatus; description: string }[] = [
+  { status: "ideation", description: "Idea being shaped \u2014 not yet open for pledges" },
   { status: "proposed", description: "Proposed and waiting for review" },
   { status: "underway", description: "Work has begun" },
   { status: "review", description: "Complete \u2014 pledgers reviewing work" },

--- a/frontend/src/pages/SubmitTask.test.tsx
+++ b/frontend/src/pages/SubmitTask.test.tsx
@@ -1,16 +1,13 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { vi } from "vitest";
 import SubmitTask from "./SubmitTask";
 import { renderWithRouter } from "../test/render";
 import { createTask } from "../api/tasks";
-import { fetchPaymentMethods } from "../api/patron";
 import { makeTask } from "../test/factories";
 
 vi.mock("../api/tasks");
-vi.mock("../api/patron");
 const mockCreateTask = vi.mocked(createTask);
-const mockFetchPaymentMethods = vi.mocked(fetchPaymentMethods);
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -21,20 +18,6 @@ vi.mock("react-router-dom", async () => {
 const mockUseAuth = vi.fn();
 vi.mock("../contexts/AuthContext", () => ({
   useAuth: () => mockUseAuth(),
-}));
-
-const mockConfirmCardSetup = vi.fn();
-const mockGetElement = vi.fn();
-
-vi.mock("@stripe/react-stripe-js", () => ({
-  Elements: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  CardElement: () => <div data-testid="card-element" />,
-  useStripe: () => ({ confirmCardSetup: mockConfirmCardSetup }),
-  useElements: () => ({ getElement: mockGetElement }),
-}));
-
-vi.mock("@stripe/stripe-js", () => ({
-  loadStripe: () => Promise.resolve({}),
 }));
 
 afterEach(() => {
@@ -178,201 +161,53 @@ describe("SubmitTask (non-admin)", () => {
       login: vi.fn(),
       logout: vi.fn(),
     });
-
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      json: () => Promise.resolve({ publishable_key: "pk_test_123" }),
-    } as Response);
-
-    mockFetchPaymentMethods.mockResolvedValue([]);
   });
 
-  it("shows loading state while Stripe loads", () => {
-    // Override fetch to return a never-resolving promise so stripePromise stays null
-    vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise(() => {}) as Promise<Response>);
+  it("shows simple form without pledge fields for non-admin", () => {
+    renderWithRouter(<SubmitTask />);
+
+    expect(screen.getByLabelText("Title *")).toBeInTheDocument();
+    expect(screen.getByLabelText("Description *")).toBeInTheDocument();
+    expect(screen.queryByText("Your Pledge *")).not.toBeInTheDocument();
+    expect(screen.queryByText("Card details")).not.toBeInTheDocument();
+  });
+
+  it("shows ideation intro text", () => {
+    renderWithRouter(<SubmitTask />);
+
+    expect(screen.getByText(/ideation/i)).toBeInTheDocument();
+  });
+
+  it("submits task without pledge and redirects", async () => {
+    mockCreateTask.mockResolvedValue(taskCreateResponse({ id: "ideation-task-id" }));
 
     renderWithRouter(<SubmitTask />);
 
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Title *")).not.toBeInTheDocument();
-  });
-
-  it("shows pledge and card fields for non-admin", async () => {
-    renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Your Pledge *")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Card details")).toBeInTheDocument();
-    expect(screen.getByTestId("card-element")).toBeInTheDocument();
-  });
-
-  it("shows preset pledge amount buttons", async () => {
-    renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "$1" })).toBeInTheDocument();
-    });
-    expect(screen.getByRole("button", { name: "$5" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "$25" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Custom" })).toBeInTheDocument();
-  });
-
-  it("submits task with pledge and confirms card", async () => {
-    const cardElement = {};
-    mockGetElement.mockReturnValue(cardElement);
-    mockConfirmCardSetup.mockResolvedValue({ error: null });
-
-    // Mock createTask - need to override the global fetch mock for this call
-    mockCreateTask.mockResolvedValue(
-      taskCreateResponse({
-        id: "pledged-task-id",
-        pledge_id: "pledge-123",
-        client_secret: "seti_secret_456",
-        publishable_key: "pk_test_123",
-      }),
-    );
-
-    renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Title *")).toBeInTheDocument();
-    });
-
-    await userEvent.type(screen.getByLabelText("Title *"), "My task");
-    await userEvent.type(screen.getByLabelText("Description *"), "Needs doing");
+    await userEvent.type(screen.getByLabelText("Title *"), "My idea");
+    await userEvent.type(screen.getByLabelText("Description *"), "A great idea");
     await userEvent.click(screen.getByRole("button", { name: "Submit Task" }));
 
     await waitFor(() => {
       expect(mockCreateTask).toHaveBeenCalledWith({
-        title: "My task",
-        description: "Needs doing",
+        title: "My idea",
+        description: "A great idea",
         criteria: undefined,
-        pledge_amount: 100, // default MIN_PLEDGE_CENTS
-        save_card: true,
       });
     });
-
-    expect(mockConfirmCardSetup).toHaveBeenCalledWith("seti_secret_456", {
-      payment_method: { card: cardElement },
-    });
-    expect(mockNavigate).toHaveBeenCalledWith("/tasks/pledged-task-id");
+    expect(mockNavigate).toHaveBeenCalledWith("/tasks/ideation-task-id");
   });
 
-  it("shows error when createTask fails", async () => {
-    mockGetElement.mockReturnValue({});
-    mockCreateTask.mockRejectedValue(new Error("A pledge is required when submitting a task"));
+  it("shows error on submission failure", async () => {
+    mockCreateTask.mockRejectedValue(new Error("Server error"));
 
     renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Title *")).toBeInTheDocument();
-    });
 
     await userEvent.type(screen.getByLabelText("Title *"), "Task");
     await userEvent.type(screen.getByLabelText("Description *"), "Desc");
     await userEvent.click(screen.getByRole("button", { name: "Submit Task" }));
 
     await waitFor(() => {
-      expect(screen.getByText("A pledge is required when submitting a task")).toBeInTheDocument();
+      expect(screen.getByText("Failed to submit task. Please try again.")).toBeInTheDocument();
     });
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it("validates minimum pledge amount on client side", async () => {
-    mockGetElement.mockReturnValue({});
-
-    renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Title *")).toBeInTheDocument();
-    });
-
-    // Switch to custom amount and enter below-minimum value
-    await userEvent.click(screen.getByRole("button", { name: "Custom" }));
-    await userEvent.type(screen.getByLabelText("Amount (USD)"), "0.50");
-
-    await userEvent.type(screen.getByLabelText("Title *"), "Task");
-    await userEvent.type(screen.getByLabelText("Description *"), "Desc");
-
-    // Use fireEvent.submit to bypass HTML5 constraint validation on the
-    // number input (min=1), so we can test the JS-level validation in handleSubmit
-    fireEvent.submit(screen.getByRole("button", { name: "Submit Task" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Minimum pledge is $1.00")).toBeInTheDocument();
-    });
-    expect(mockCreateTask).not.toHaveBeenCalled();
-  });
-
-  it("shows stripe error message on card failure", async () => {
-    mockGetElement.mockReturnValue({});
-    mockConfirmCardSetup.mockResolvedValue({
-      error: { message: "Your card was declined" },
-    });
-
-    mockCreateTask.mockResolvedValue(
-      taskCreateResponse({
-        id: "task-id",
-        pledge_id: "pledge-id",
-        client_secret: "seti_secret",
-        publishable_key: "pk_test",
-      }),
-    );
-
-    renderWithRouter(<SubmitTask />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Title *")).toBeInTheDocument();
-    });
-
-    await userEvent.type(screen.getByLabelText("Title *"), "Task");
-    await userEvent.type(screen.getByLabelText("Description *"), "Desc");
-    await userEvent.click(screen.getByRole("button", { name: "Submit Task" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Your card was declined")).toBeInTheDocument();
-    });
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it("shows saved PM selector when methods exist", async () => {
-    mockFetchPaymentMethods.mockResolvedValue([
-      { id: "pm_saved", brand: "visa", last4: "4242", exp_month: 12, exp_year: 2028 },
-    ]);
-
-    renderWithRouter(<SubmitTask />);
-
-    expect(await screen.findByText("…4242")).toBeInTheDocument();
-    expect(screen.getByText("New card")).toBeInTheDocument();
-    expect(screen.queryByTestId("card-element")).not.toBeInTheDocument();
-  });
-
-  it("submits with saved PM and passes payment_method_id", async () => {
-    mockFetchPaymentMethods.mockResolvedValue([
-      { id: "pm_saved", brand: "visa", last4: "4242", exp_month: 12, exp_year: 2028 },
-    ]);
-    mockCreateTask.mockResolvedValue(
-      taskCreateResponse({ id: "task-with-saved-pm", client_secret: null }),
-    );
-
-    renderWithRouter(<SubmitTask />);
-
-    await screen.findByText("…4242");
-
-    await userEvent.type(screen.getByLabelText("Title *"), "My task");
-    await userEvent.type(screen.getByLabelText("Description *"), "Needs doing");
-    await userEvent.click(screen.getByRole("button", { name: "Submit Task" }));
-
-    await waitFor(() => {
-      expect(mockCreateTask).toHaveBeenCalledWith({
-        title: "My task",
-        description: "Needs doing",
-        criteria: undefined,
-        pledge_amount: 100,
-        payment_method_id: "pm_saved",
-      });
-    });
-    expect(mockConfirmCardSetup).not.toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith("/tasks/task-with-saved-pm");
   });
 });

--- a/frontend/src/pages/SubmitTask.tsx
+++ b/frontend/src/pages/SubmitTask.tsx
@@ -1,169 +1,10 @@
-import { useState, useEffect, type FormEvent } from "react";
-import { useNavigate } from "react-router-dom";
-import { loadStripe } from "@stripe/stripe-js";
-import { Elements, CardElement, useStripe, useElements } from "@stripe/react-stripe-js";
-import { API_BASE } from "../api/client";
 import { createTask } from "../api/tasks";
-import { fetchPaymentMethods } from "../api/patron";
-import Spinner from "../components/Spinner";
-import { TaskFormFields } from "../components/TaskForm";
 import TaskForm from "../components/TaskForm";
-import CardPaymentFields, { useCardPaymentSelection } from "../components/CardPaymentFields";
 import { useAuth } from "../contexts/AuthContext";
-import { MIN_PLEDGE_CENTS, PRESET_AMOUNTS } from "../constants";
-import { formatCents } from "../utils/formatting";
-import type { SavedPaymentMethod } from "../api/types";
-
-function PledgedTaskForm({ savedMethods }: { savedMethods: SavedPaymentMethod[] }) {
-  const stripe = useStripe();
-  const elements = useElements();
-  const navigate = useNavigate();
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [criteria, setCriteria] = useState("");
-  const [amount, setAmount] = useState(MIN_PLEDGE_CENTS);
-  const [customAmount, setCustomAmount] = useState("");
-  const [isCustom, setIsCustom] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
-  const [paymentSelection, setPaymentSelection] = useCardPaymentSelection(savedMethods);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    if (!stripe || !elements) return;
-
-    const finalAmount = isCustom ? Math.round(parseFloat(customAmount) * 100) : amount;
-    const minDollars = (MIN_PLEDGE_CENTS / 100).toFixed(2);
-    if (!finalAmount || finalAmount < MIN_PLEDGE_CENTS) {
-      setError(`Minimum pledge is $${minDollars}`);
-      return;
-    }
-
-    setSubmitting(true);
-    setError("");
-
-    try {
-      const resp = await createTask({
-        title: title.trim(),
-        description: description.trim(),
-        criteria: criteria.trim() || undefined,
-        pledge_amount: finalAmount,
-        ...(paymentSelection.usingSavedCard
-          ? { payment_method_id: paymentSelection.selectedPM }
-          : { save_card: paymentSelection.saveCard }),
-      });
-
-      if (resp.client_secret) {
-        const card = elements.getElement(CardElement);
-        if (!card) {
-          setError("Card element not found");
-          setSubmitting(false);
-          return;
-        }
-
-        const { error: stripeError } = await stripe.confirmCardSetup(resp.client_secret, {
-          payment_method: { card },
-        });
-
-        if (stripeError) {
-          setError(stripeError.message ?? "Card setup failed");
-          setSubmitting(false);
-          return;
-        }
-      }
-
-      navigate(`/tasks/${resp.id}`);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to submit task. Please try again.");
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="submit-task-form">
-      <TaskFormFields
-        title={title} setTitle={setTitle}
-        description={description} setDescription={setDescription}
-        criteria={criteria} setCriteria={setCriteria}
-      />
-
-      <div className="form-field">
-        <label>Your Pledge *</label>
-        <div className="amount-selector">
-          {PRESET_AMOUNTS.map((preset) => (
-            <button
-              key={preset}
-              type="button"
-              className={`amount-btn ${!isCustom && amount === preset ? "active" : ""}`}
-              onClick={() => { setAmount(preset); setIsCustom(false); }}
-            >
-              {formatCents(preset)}
-            </button>
-          ))}
-          <button
-            type="button"
-            className={`amount-btn ${isCustom ? "active" : ""}`}
-            onClick={() => setIsCustom(true)}
-          >
-            Custom
-          </button>
-        </div>
-
-        {isCustom && (
-          <div className="custom-amount">
-            <label htmlFor="custom-amount">Amount (USD)</label>
-            <input
-              id="custom-amount"
-              type="number"
-              min={MIN_PLEDGE_CENTS / 100}
-              step="0.01"
-              placeholder={(MIN_PLEDGE_CENTS / 100).toFixed(2)}
-              value={customAmount}
-              onChange={(e) => setCustomAmount(e.target.value)}
-            />
-          </div>
-        )}
-      </div>
-
-      <CardPaymentFields
-        savedMethods={savedMethods}
-        value={paymentSelection}
-        onChange={setPaymentSelection}
-      />
-
-      {error && <p className="form-error">{error}</p>}
-
-      <button
-        type="submit"
-        className="btn btn-primary"
-        disabled={submitting || !stripe}
-      >
-        {submitting ? <><Spinner /> Submitting...</> : "Submit Task"}
-      </button>
-    </form>
-  );
-}
 
 export default function SubmitTask() {
   const { patron } = useAuth();
-  const isAdmin = patron?.is_admin ?? false;
   const isBanned = patron?.is_banned ?? false;
-  const [stripePromise, setStripePromise] = useState<ReturnType<typeof loadStripe> | null>(null);
-  const [savedMethods, setSavedMethods] = useState<SavedPaymentMethod[]>([]);
-
-  useEffect(() => {
-    if (isAdmin || isBanned) return;
-
-    Promise.all([
-      fetch(`${API_BASE}/config/stripe`).then((r) => r.json()),
-      fetchPaymentMethods().catch(() => [] as SavedPaymentMethod[]),
-    ]).then(([config, methods]) => {
-      if (config.publishable_key) {
-        setStripePromise(loadStripe(config.publishable_key));
-      }
-      setSavedMethods(methods);
-    });
-  }, [isAdmin, isBanned]);
 
   if (isBanned) {
     return (
@@ -176,38 +17,20 @@ export default function SubmitTask() {
     );
   }
 
-  if (isAdmin) {
-    return (
-      <div className="submit-task-page">
-        <h1>Submit a Task</h1>
-        <p className="submit-task-intro">
-          Propose a task for Brandon to work on. Describe what you'd like done and
-          what "done" looks like.
-        </p>
-        <TaskForm
-          onSubmit={async (data) => {
-            const task = await createTask(data);
-            return `/tasks/${task.id}`;
-          }}
-        />
-      </div>
-    );
-  }
-
-  if (!stripePromise) {
-    return <p className="page-message">Loading...</p>;
-  }
-
   return (
     <div className="submit-task-page">
       <h1>Submit a Task</h1>
       <p className="submit-task-intro">
-        Propose a task for Brandon to work on. Describe what you'd like done and
-        what "done" looks like. A pledge is required to submit a task.
+        Propose an idea for Brandon to work on. Describe what you'd like done and
+        what "done" looks like. Your task will start in ideation where you can
+        refine it with community feedback before it opens for pledges.
       </p>
-      <Elements stripe={stripePromise}>
-        <PledgedTaskForm savedMethods={savedMethods} />
-      </Elements>
+      <TaskForm
+        onSubmit={async (data) => {
+          const task = await createTask(data);
+          return `/tasks/${task.id}`;
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/TaskBoard.test.tsx
+++ b/frontend/src/pages/TaskBoard.test.tsx
@@ -89,4 +89,23 @@ describe("TaskBoard", () => {
       expect.objectContaining({ status: "underway" }),
     );
   });
+
+  it("filter dropdown includes Ideation option", async () => {
+    const user = userEvent.setup();
+    mockListTasks.mockResolvedValue(makeResponse([]));
+    renderBoard();
+
+    await screen.findByText("No tasks found.");
+    const callCountAfterMount = mockListTasks.mock.calls.length;
+
+    const filterSelect = screen.getByRole("combobox", { name: /filter/i });
+    await user.selectOptions(filterSelect, "ideation");
+
+    await waitFor(() =>
+      expect(mockListTasks.mock.calls.length).toBeGreaterThan(callCountAfterMount),
+    );
+    expect(mockListTasks).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: "ideation" }),
+    );
+  });
 });

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -15,6 +15,7 @@ const SORT_MAP: Record<SortOption, { sort_by: "pledge_total" | "created_at"; sor
 
 const STATUS_OPTIONS: { value: TaskStatus | ""; label: string }[] = [
   { value: "", label: "All" },
+  { value: "ideation", label: "Ideation" },
   { value: "proposed", label: "Proposed" },
   { value: "underway", label: "Underway" },
   { value: "collecting", label: "Collecting" },

--- a/frontend/src/pages/TaskDetail.test.tsx
+++ b/frontend/src/pages/TaskDetail.test.tsx
@@ -2,7 +2,7 @@ import { screen } from "@testing-library/react";
 import { Route, Routes } from "react-router-dom";
 import TaskDetail from "./TaskDetail";
 import { getTask } from "../api/tasks";
-import { makeTaskDetail, makeUpdate } from "../test/factories";
+import { makeTaskDetail, makeUpdate, makeComment } from "../test/factories";
 import { renderWithRouter } from "../test/render";
 
 vi.mock("../api/tasks");
@@ -16,6 +16,7 @@ vi.mock("../api/patron", () => ({
   fetchPaymentMethods: vi.fn().mockResolvedValue([]),
 }));
 vi.mock("../api/admin");
+vi.mock("../api/comments");
 vi.mock("@stripe/stripe-js");
 
 const mockUseAuth = vi.fn();
@@ -244,5 +245,79 @@ describe("TaskDetail", () => {
     renderDetail();
     await screen.findByText("Fix the bridge");
     expect(screen.queryByRole("link", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("hides pledge stats when in ideation", async () => {
+    mockGetTask.mockResolvedValue(makeTaskDetail({ status: "ideation", pledge_count: 0, pledge_total: 0 }));
+    renderDetail();
+    await screen.findByText("Description");
+    expect(screen.queryByText(/backers/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pledged/)).not.toBeInTheDocument();
+  });
+
+  it("hides Pledge button for ideation tasks", async () => {
+    mockGetTask.mockResolvedValue(makeTaskDetail({ status: "ideation" }));
+    renderDetail();
+    await screen.findByText("Description");
+    expect(screen.queryByRole("button", { name: "Pledge" })).not.toBeInTheDocument();
+  });
+
+  it("shows Edit link for task author in ideation", async () => {
+    mockUseAuth.mockReturnValue({
+      patron: { id: "author-1", email: "author@example.com", display_name: null, is_admin: false, is_banned: false },
+      loading: false, login: vi.fn(), logout: vi.fn(),
+    });
+    mockGetTask.mockResolvedValue(makeTaskDetail({ id: "task-ideation", status: "ideation", submitted_by: "author-1" }));
+    renderDetail("task-ideation");
+    const editLink = await screen.findByRole("link", { name: "Edit" });
+    expect(editLink).toHaveAttribute("href", "/tasks/task-ideation/edit");
+  });
+
+  it("hides Edit link for non-author non-admin in ideation", async () => {
+    mockUseAuth.mockReturnValue({
+      patron: { id: "other-1", email: "other@example.com", display_name: null, is_admin: false, is_banned: false },
+      loading: false, login: vi.fn(), logout: vi.fn(),
+    });
+    mockGetTask.mockResolvedValue(makeTaskDetail({ status: "ideation", submitted_by: "author-1" }));
+    renderDetail();
+    await screen.findByText("Fix the bridge");
+    expect(screen.queryByRole("link", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("hides Edit link for author when not in ideation", async () => {
+    mockUseAuth.mockReturnValue({
+      patron: { id: "author-1", email: "author@example.com", display_name: null, is_admin: false, is_banned: false },
+      loading: false, login: vi.fn(), logout: vi.fn(),
+    });
+    mockGetTask.mockResolvedValue(makeTaskDetail({ status: "proposed", submitted_by: "author-1" }));
+    renderDetail();
+    await screen.findByText("Fix the bridge");
+    expect(screen.queryByRole("link", { name: "Edit" })).not.toBeInTheDocument();
+  });
+
+  it("renders comments section", async () => {
+    mockGetTask.mockResolvedValue(makeTaskDetail({
+      comments: [
+        makeComment({ id: "c1", body: "Great idea!" }),
+      ],
+    }));
+    renderDetail();
+    expect(await screen.findByText("Comments")).toBeInTheDocument();
+    expect(screen.getByText("Great idea!")).toBeInTheDocument();
+  });
+
+  it("shows 'No comments yet.' when comments are empty", async () => {
+    mockGetTask.mockResolvedValue(makeTaskDetail({ comments: [] }));
+    renderDetail();
+    expect(await screen.findByText("No comments yet.")).toBeInTheDocument();
+  });
+
+  it("shows admin ideation actions (Move to Proposed, Decline)", async () => {
+    mockUseAuth.mockReturnValue({ patron: { is_admin: true }, loading: false, login: vi.fn(), logout: vi.fn() });
+    mockGetTask.mockResolvedValue(makeTaskDetail({ status: "ideation" }));
+    renderDetail();
+    expect(await screen.findByText("Admin Actions")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Move to Proposed" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Decline" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -6,6 +6,7 @@ import StatusBadge from "../components/StatusBadge";
 import useFetch from "../hooks/useFetch";
 import PledgeWidget from "../components/PledgeWidget";
 import AdminTaskActions from "../components/AdminTaskActions";
+import CommentSection from "../components/CommentSection";
 import { useAuth } from "../contexts/AuthContext";
 
 function MarkdownSection({ title, children, className }: { title: string; children: string; className?: string }) {
@@ -39,7 +40,9 @@ export default function TaskDetail() {
       <div className="task-detail-header">
         <div className="task-detail-header-top">
           <StatusBadge status={task.status} />
-          {isAdmin && <Link to={`/tasks/${task.id}/edit`} className="btn btn-secondary btn-sm">Edit</Link>}
+          {(isAdmin || (patron && task.submitted_by === patron.id && task.status === "ideation")) && (
+            <Link to={`/tasks/${task.id}/edit`} className="btn btn-secondary btn-sm">Edit</Link>
+          )}
         </div>
         <h1 className="task-detail-title">{task.title}</h1>
         <p className="task-detail-stats">
@@ -49,13 +52,17 @@ export default function TaskDetail() {
               <Link to={`/patrons/${task.submitted_by_patron.id}`} className="task-detail-creator">
                 {task.submitted_by_patron.display_name ?? "Anonymous"}
               </Link>
-              {" "}&middot;{" "}
+              {task.status !== "ideation" && <>{" "}&middot;{" "}</>}
             </>
           )}
-          {formatBackers(task.pledge_count)} &middot;{" "}
-          {formatCents(task.pledge_total)} pledged
-          {task.status === "completed" && task.collected_total > 0 && (
-            <> &middot; Collected {formatCents(task.collected_total)} of {formatCents(task.pledge_total)} pledged</>
+          {task.status !== "ideation" && (
+            <>
+              {formatBackers(task.pledge_count)} &middot;{" "}
+              {formatCents(task.pledge_total)} pledged
+              {task.status === "completed" && task.collected_total > 0 && (
+                <> &middot; Collected {formatCents(task.collected_total)} of {formatCents(task.pledge_total)} pledged</>
+              )}
+            </>
           )}
         </p>
       </div>
@@ -96,6 +103,8 @@ export default function TaskDetail() {
           </div>
         </section>
       )}
+
+      <CommentSection taskId={task.id} comments={task.comments} onComment={refetch} />
 
       <PledgeWidget task={task} />
     </div>

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -1,4 +1,4 @@
-import type { TaskRead, TaskDetailRead, TaskListResponse, UpdateRead, PatronPledgeRead, NotificationRead, PatronProfileRead, EmailPreference } from "../api/types";
+import type { TaskRead, TaskDetailRead, TaskListResponse, UpdateRead, CommentRead, PatronPledgeRead, NotificationRead, PatronProfileRead, EmailPreference } from "../api/types";
 
 export function makeTask(overrides: Partial<TaskRead> = {}): TaskRead {
   return {
@@ -26,6 +26,23 @@ export function makeTaskDetail(overrides: Partial<TaskDetailRead> = {}): TaskDet
   return {
     ...makeTask(overrides),
     updates: [],
+    comments: [],
+    ...overrides,
+  };
+}
+
+export function makeComment(overrides: Partial<CommentRead> = {}): CommentRead {
+  return {
+    id: "comment-1",
+    task_id: "abc-123",
+    author_id: "patron-1",
+    author: {
+      id: "patron-1",
+      display_name: "Jane Doe",
+      created_at: "2025-01-01T00:00:00Z",
+    },
+    body: "This is a great idea!",
+    created_at: "2025-02-01T00:00:00Z",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Adds new **ideation** task status before "proposed", making it the default for new tasks
- Introduces a **comment system** (model, API endpoints, frontend UI) so patrons can discuss tasks during ideation
- Allows task **authors to edit** title, description, and criteria while in ideation status
- Removes the pledge requirement at task creation (pledges happen after ideation)
- Simplifies the SubmitTask form (no longer collects pledge info upfront)

## Test plan
- [x] Backend: 207 tests passing (includes new comment and ideation transition tests)
- [x] Frontend: 284 tests passing (includes new CommentSection and AdminTaskActions ideation tests)
- [ ] Manual: Create a task, verify it starts in ideation, add comments, then promote to proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)